### PR TITLE
Version updates for 5 remediations removing multiple values for life cycle variable

### DIFF
--- a/Datasets/lib/xml/datasets/VectorBase.xml
+++ b/Datasets/lib/xml/datasets/VectorBase.xml
@@ -1373,7 +1373,7 @@
   <dataset class="ISATabPopBio">
     <prop name="projectName">$$projectName$$</prop>
     <prop name="studyName">VBP0000182</prop>
-    <prop name="version">2023-08-11</prop>
+    <prop name="version">2024-01-18</prop>
     <prop name="webDisplayOntologyName">OntologyTerm_popbio_RSRC</prop>
     <prop name="speciesReconciliationOntologySpec">OntologyTerm_popbio_taxonomy_RSRC|dontcare</prop>
     <prop name="speciesReconciliationFallbackSpecies"></prop>
@@ -2949,7 +2949,7 @@
   <dataset class="ISATabPopBio">
     <prop name="projectName">$$projectName$$</prop>
     <prop name="studyName">VBP0000365</prop>
-    <prop name="version">2023-08-11</prop>
+    <prop name="version">2024-01-18</prop>
     <prop name="webDisplayOntologyName">OntologyTerm_popbio_RSRC</prop>
     <prop name="speciesReconciliationOntologySpec">OntologyTerm_popbio_taxonomy_RSRC|dontcare</prop>
     <prop name="speciesReconciliationFallbackSpecies"></prop>
@@ -6396,7 +6396,7 @@
   <dataset class="ISATabPopBio">
     <prop name="projectName">$$projectName$$</prop>
     <prop name="studyName">VBP0000805</prop>
-    <prop name="version">2023-08-11</prop>
+    <prop name="version">2024-01-18</prop>
     <prop name="webDisplayOntologyName">OntologyTerm_popbio_RSRC</prop>
     <prop name="speciesReconciliationOntologySpec">OntologyTerm_popbio_taxonomy_RSRC|dontcare</prop>
     <prop name="speciesReconciliationFallbackSpecies"></prop>
@@ -6423,7 +6423,7 @@
   <dataset class="ISATabPopBio">
     <prop name="projectName">$$projectName$$</prop>
     <prop name="studyName">VBP0000808</prop>
-    <prop name="version">2023-08-11</prop>
+    <prop name="version">2024-01-18</prop>
     <prop name="webDisplayOntologyName">OntologyTerm_popbio_RSRC</prop>
     <prop name="speciesReconciliationOntologySpec">OntologyTerm_popbio_taxonomy_RSRC|dontcare</prop>
     <prop name="speciesReconciliationFallbackSpecies"></prop>
@@ -6450,7 +6450,7 @@
   <dataset class="ISATabPopBio">
     <prop name="projectName">$$projectName$$</prop>
     <prop name="studyName">VBP0000811</prop>
-    <prop name="version">2023-08-11</prop>
+    <prop name="version">2024-01-18</prop>
     <prop name="webDisplayOntologyName">OntologyTerm_popbio_RSRC</prop>
     <prop name="speciesReconciliationOntologySpec">OntologyTerm_popbio_taxonomy_RSRC|dontcare</prop>
     <prop name="speciesReconciliationFallbackSpecies"></prop>


### PR DESCRIPTION
Life cycle stage variable was multi-valued for 5 datasets in the megastudy.

This was messing up imputed zero stuff.

This is how the files were fixed:
https://veupathdb.atlassian.net/wiki/spaces/~61aa65f9fe9f300068d0b8bd/pages/483885069/Work+log+for+manualDelivery+ISA-Tab+remediation+of+multi-valued+developmental+stages

The new files are in manual delivery.

This PR, should you choose to merge it, will provide the version updates in EdaDatasets VectorBase.xml

No OWL file updates are required.